### PR TITLE
CBP-14608 use the default version of cosign release

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -225,8 +225,6 @@ jobs:
 
       - name: Set up Cosign
         uses: sigstore/cosign-installer@v3
-        with:
-          cosign-release: v2.0.1
         if: inputs.publish
 
       - name: Set up Syft


### PR DESCRIPTION
The pinned version seems outdated and the upstream repo already maintains the [latest version as default](https://github.com/sigstore/cosign-installer/blob/d58896d6a1865668819e1d91763c7751a165e159/action.yml#L13).