### PR TITLE
CBP-14608: remove the step to install the chartmuseum plugin

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -121,9 +121,5 @@ jobs:
           fi
 
       - if: ${{ steps.set-helm-push-enabled.outputs.helm_push_enabled == 1 }}
-        name: Install Helm ChartMuseum push plugin
-        run: helm plugin install "https://github.com/chartmuseum/helm-push.git" --version "${{ env.HELM_PLUGIN_CHARTMUSEUM_PUSH_VERSION }}"
-
-      - if: ${{ steps.set-helm-push-enabled.outputs.helm_push_enabled == 1 }}
         name: Push Helm chart
         run: helm push "${{ steps.package-chart.outputs.helm_package_path }}" "${{ env.HELM_PUSH_REPOSITORY_NAME }}"


### PR DESCRIPTION
We are using an AWS ECR OCI registry as the chart repository, therefore we do not need to install the [chartmuseum](https://github.com/chartmuseum/helm-push) plugin.