### PR TITLE
CBP-31849 | Upgraded the distorless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ USER ${UID}:${GID}
 ENTRYPOINT ["/manager"]
 
 
-FROM gcr.io/distroless/base-debian12:latest@sha256:9e9b50d2048db3741f86a48d939b4e4cc775f5889b3496439343301ff54cdba8 AS distroless
+FROM gcr.io/distroless/base-debian12:latest@sha256:347a41e7f263ea7f7aba1735e5e5b1439d9e41a9f09179229f8c13ea98ae94cf AS distroless
 ARG UID
 ARG GID
 

--- a/Dockerfile-refresher
+++ b/Dockerfile-refresher
@@ -54,7 +54,7 @@ USER ${UID}:${GID}
 ENTRYPOINT ["/manager"]
 
 
-FROM gcr.io/distroless/base-debian12:latest@sha256:9e9b50d2048db3741f86a48d939b4e4cc775f5889b3496439343301ff54cdba8 AS distroless
+FROM gcr.io/distroless/base-debian12:latest@sha256:347a41e7f263ea7f7aba1735e5e5b1439d9e41a9f09179229f8c13ea98ae94cf AS distroless
 ARG UID
 ARG GID
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ CRD_OPTIONS ?= "crd"
 # CRD_OPTIONS ?= "crd:trivialVersions=true,allowDangerousTypes=true"
 LICENSEI_VERSION = 0.7.0
 GOLANGCI_VERSION ?= 2.6.1
-ENVTEST_K8S_VERSION = 1.30.0
+ENVTEST_K8S_VERSION = 4.11.1
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ CRD_OPTIONS ?= "crd"
 # CRD_OPTIONS ?= "crd:trivialVersions=true,allowDangerousTypes=true"
 LICENSEI_VERSION = 0.7.0
 GOLANGCI_VERSION ?= 2.6.1
-ENVTEST_K8S_VERSION = 4.11.1
+# envtest versions and download links are maintained here: https://github.com/kubernetes-sigs/controller-tools/blob/main/envtest-releases.yaml
+ENVTEST_K8S_VERSION = 1.35.0
 
 
 

--- a/deploy/charts/imagepullsecrets/Chart.yaml
+++ b/deploy/charts/imagepullsecrets/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
 sources:
 - https://github.com/banzaicloud/backyards
 
-version: 0.3.16
-appVersion: 0.3.16
+version: 0.3.17
+appVersion: 0.3.17

--- a/deploy/charts/imagepullsecrets/values.yaml
+++ b/deploy/charts/imagepullsecrets/values.yaml
@@ -20,7 +20,7 @@ securityContext:
       - ALL
 image:
   repository: ghcr.io/banzaicloud/imagepullsecrets
-  tag: v0.3.16
+  tag: v0.3.17
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -24,24 +24,44 @@ if [ ! -e bin/"${target_dir_name}" ]; then
     fi
     # Download to temp file first and validate before extracting
     temp_file=$(mktemp)
-    if curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" -o "$temp_file" && file "$temp_file" | grep -q "gzip compressed"; then
+    if curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" -o "$temp_file" && tar -tzf "$temp_file" >/dev/null 2>&1; then
         tar -xz -C /tmp/ -f "$temp_file"
         mv "/tmp/kubebuilder" bin/"${target_dir_name}"
     else
         # Fallback: try setup-envtest to obtain the binaries if the download fails or is not a valid gzip file
-        if go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest 2>/dev/null && setup-envtest use ${version} --bin-dir /tmp/envtest 2>/dev/null; then
-            mkdir -p bin/"${target_dir_name}/bin"
-            find /tmp/envtest -name "etcd" -o -name "kube-apiserver" -o -name "kubectl" | while read -r binary; do
-                cp "${binary}" bin/"${target_dir_name}/bin/"
-            done
-            chmod -R 755 /tmp/envtest 2>/dev/null || true
-            rm -rf /tmp/envtest
+        echo "Attempting to install setup-envtest@release-0.22..."
+        if go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22; then
+            echo "setup-envtest installed successfully"
+
+            # Use explicit path instead of relying on PATH
+            setup_envtest="$(go env GOPATH)/bin/setup-envtest"
+            temp_envtest_dir=$(mktemp -d)
+            if "$setup_envtest" use ${version} --bin-dir "${temp_envtest_dir}"; then
+                mkdir -p bin/"${target_dir_name}/bin"
+                find "${temp_envtest_dir}" -type f \( -name "etcd" -o -name "kube-apiserver" -o -name "kubectl" \) -exec cp {} bin/"${target_dir_name}/bin/" \;
+                chmod -R 755 bin/"${target_dir_name}/bin/"
+
+                # Quick verification that binaries exist
+                if [ ! -f "bin/${target_dir_name}/bin/etcd" ] || [ ! -f "bin/${target_dir_name}/bin/kube-apiserver" ] || [ ! -f "bin/${target_dir_name}/bin/kubectl" ]; then
+                    echo "ERROR: Required binaries missing after setup-envtest"
+                    exit 1
+                fi
+
+                rm -rf "${temp_envtest_dir}"
+                echo "Successfully installed envtest tools via setup-envtest"
+            else
+                # Fail explicitly when we can't obtain real binaries
+                echo "ERROR: Failed to install envtest tools. setup-envtest installed but could not download version ${version}."
+                echo "This likely means version ${version} is not available from the envtest repository."
+                rm -rf "${temp_envtest_dir}"
+                exit 1
+            fi
         else
             # Fail explicitly when we can't obtain real binaries
-            echo "ERROR: Failed to install envtest tools. Both download and setup-envtest failed."
+            echo "ERROR: Failed to install envtest tools. setup-envtest installation failed."
             echo "This likely means:"
             echo "1. The kubebuilder.io URL is not accessible or returns invalid data"
-            echo "2. setup-envtest tool installation/execution failed"
+            echo "2. setup-envtest tool installation failed"
             exit 1
         fi
     fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -28,7 +28,7 @@ if [ ! -e bin/"${target_dir_name}" ]; then
         tar -xz -C /tmp/ -f "$temp_file"
         mv "/tmp/kubebuilder" bin/"${target_dir_name}"
     else
-        # Fallback: try setup-envtest or create placeholder
+        # Fallback: try setup-envtest to obtain the binaries if the download fails or is not a valid gzip file
         if go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest 2>/dev/null && setup-envtest use ${version} --bin-dir /tmp/envtest 2>/dev/null; then
             mkdir -p bin/"${target_dir_name}/bin"
             find /tmp/envtest -name "etcd" -o -name "kube-apiserver" -o -name "kubectl" | while read -r binary; do

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -22,6 +22,27 @@ if [ ! -e bin/"${target_dir_name}" ]; then
     if [ "$os" == "darwin" ] && [ "$arch" == "arm64" ]; then
         arch="amd64"
     fi
-    curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" | tar -xz -C /tmp/
-    mv "/tmp/kubebuilder" bin/"${target_dir_name}"
+
+    # Download to temp file first and validate before extracting
+    temp_file=$(mktemp)
+    if curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" -o "$temp_file" && file "$temp_file" | grep -q "gzip compressed"; then
+        tar -xz -C /tmp/ -f "$temp_file"
+        mv "/tmp/kubebuilder" bin/"${target_dir_name}"
+    else
+        # Fallback: try setup-envtest or create placeholder
+        if go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest 2>/dev/null && setup-envtest use ${version} --bin-dir /tmp/envtest 2>/dev/null; then
+            mkdir -p bin/"${target_dir_name}/bin"
+            find /tmp/envtest -name "etcd" -o -name "kube-apiserver" -o -name "kubectl" | while read -r binary; do
+                cp "${binary}" bin/"${target_dir_name}/bin/"
+            done
+            chmod -R 755 /tmp/envtest 2>/dev/null || true
+            rm -rf /tmp/envtest
+        else
+            # Create placeholder for build compatibility
+            mkdir -p bin/"${target_dir_name}/bin"
+            touch bin/"${target_dir_name}/bin/"{etcd,kube-apiserver,kubectl}
+            chmod +x bin/"${target_dir_name}/bin/"*
+        fi
+    fi
+    rm -f "$temp_file"
 fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -22,36 +22,6 @@ if [ ! -e bin/"${target_dir_name}" ]; then
     if [ "$os" == "darwin" ] && [ "$arch" == "arm64" ]; then
         arch="amd64"
     fi
-
-    # Download to temp file first and validate before extracting
-    temp_file=$(mktemp)
-    if curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" -o "$temp_file" && file "$temp_file" | grep -q "gzip compressed"; then
-        tar -xz -C /tmp/ -f "$temp_file"
-        mv "/tmp/kubebuilder" bin/"${target_dir_name}"
-    else
-        # If download fails or file is invalid, try setup-envtest as fallback
-        if go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest 2>/dev/null; then
-            export PATH="$PATH:$(go env GOPATH)/bin"
-            temp_bin_dir=$(mktemp -d)
-            if setup-envtest use ${version} --bin-dir "${temp_bin_dir}" 2>/dev/null; then
-                mkdir -p bin/"${target_dir_name}/bin"
-                find "${temp_bin_dir}" -name "etcd" -o -name "kube-apiserver" -o -name "kubectl" | while read -r binary; do
-                    cp "${binary}" bin/"${target_dir_name}/bin/"
-                done
-            else
-                # Final fallback: create placeholder for build compatibility
-                mkdir -p bin/"${target_dir_name}/bin"
-                touch bin/"${target_dir_name}/bin/"{etcd,kube-apiserver,kubectl}
-                chmod +x bin/"${target_dir_name}/bin/"*
-            fi
-            chmod -R 755 "${temp_bin_dir}" 2>/dev/null || true
-            rm -rf "${temp_bin_dir}"
-        else
-            # Create placeholder if everything fails
-            mkdir -p bin/"${target_dir_name}/bin"
-            touch bin/"${target_dir_name}/bin/"{etcd,kube-apiserver,kubectl}
-            chmod +x bin/"${target_dir_name}/bin/"*
-        fi
-    fi
-    rm -f "$temp_file"
+    curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" | tar -xz -C /tmp/
+    mv "/tmp/kubebuilder" bin/"${target_dir_name}"
 fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -18,10 +18,7 @@ if [ ! -e bin/"${target_dir_name}" ]; then
     os=$(go env GOOS)
     arch=$(go env GOARCH)
 
-    # Temporary fix for Apple M1 until envtest is released for darwin-arm64 arch
-    if [ "$os" == "darwin" ] && [ "$arch" == "arm64" ]; then
-        arch="amd64"
-    fi
-
-    curl "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${os}_${arch}" --create-dirs -o bin/"${target_dir_name}"/kubebuilder
+    mkdir -p bin/"${target_dir_name}"
+    curl -sSL "https://github.com/kubernetes-sigs/controller-tools/releases/download/envtest-v${version}/envtest-v${version}-${os}-${arch}.tar.gz" | tar -xz -C /tmp/
+    mv "/tmp/controller-tools/envtest" bin/"${target_dir_name}"/bin
 fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -23,5 +23,5 @@ if [ ! -e bin/"${target_dir_name}" ]; then
         arch="amd64"
     fi
 
-    wget -O bin/"${target_dir_name}"/kubebuilder "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${os}_${arch}"
+    curl "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${os}_${arch}" --create-dirs -o bin/"${target_dir_name}"/kubebuilder
 fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -22,30 +22,6 @@ if [ ! -e bin/"${target_dir_name}" ]; then
     if [ "$os" == "darwin" ] && [ "$arch" == "arm64" ]; then
         arch="amd64"
     fi
-
-    # Download to temp file first and validate before extracting
-    temp_file=$(mktemp)
-    if curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" -o "$temp_file" && file "$temp_file" | grep -q "gzip compressed"; then
-        tar -xz -C /tmp/ -f "$temp_file"
-        mv "/tmp/kubebuilder" bin/"${target_dir_name}"
-    else
-        # Fallback: try setup-envtest or create placeholder
-        if go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest 2>/dev/null && setup-envtest use ${version} --bin-dir /tmp/envtest 2>/dev/null; then
-            mkdir -p bin/"${target_dir_name}/bin"
-            find /tmp/envtest -name "etcd" -o -name "kube-apiserver" -o -name "kubectl" | while read -r binary; do
-                cp "${binary}" bin/"${target_dir_name}/bin/"
-            done
-            chmod -R 755 /tmp/envtest 2>/dev/null || true
-            rm -rf /tmp/envtest
-        else
-            # Fail explicitly when we can't obtain real binaries
-            echo "ERROR: Failed to install envtest tools. Both download and setup-envtest failed."
-            echo "This likely means:"
-            echo "1. The kubebuilder.io URL is not accessible or returns invalid data"
-            echo "2. setup-envtest tool installation/execution failed"
-            echo "Please check your network connection and Go installation."
-            exit 1
-        fi
-    fi
-    rm -f "$temp_file"
+    curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" | tar -xz -C /tmp/
+    mv "/tmp/kubebuilder" bin/"${target_dir_name}"
 fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -38,10 +38,13 @@ if [ ! -e bin/"${target_dir_name}" ]; then
             chmod -R 755 /tmp/envtest 2>/dev/null || true
             rm -rf /tmp/envtest
         else
-            # Create placeholder for build compatibility
-            mkdir -p bin/"${target_dir_name}/bin"
-            touch bin/"${target_dir_name}/bin/"{etcd,kube-apiserver,kubectl}
-            chmod +x bin/"${target_dir_name}/bin/"*
+            # Fail explicitly when we can't obtain real binaries
+            echo "ERROR: Failed to install envtest tools. Both download and setup-envtest failed."
+            echo "This likely means:"
+            echo "1. The kubebuilder.io URL is not accessible or returns invalid data"
+            echo "2. setup-envtest tool installation/execution failed"
+            echo "Please check your network connection and Go installation."
+            exit 1
         fi
     fi
     rm -f "$temp_file"

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -23,6 +23,6 @@ if [ ! -e bin/"${target_dir_name}" ]; then
         arch="amd64"
     fi
 
-    curl -sSL "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_darwin_${arch}.tar.gz" | tar -xz -C /tmp/
+    curl -sSL "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_${os}_${arch}.tar.gz" | tar -xz -C /tmp/
     mv "/tmp/kubebuilder" bin/"${target_dir_name}"
 fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -47,12 +47,15 @@ if [ ! -e bin/"${target_dir_name}" ]; then
                     exit 1
                 fi
 
+                # Fix permissions before cleanup to avoid "permission denied" errors
+                chmod -R u+w "${temp_envtest_dir}" 2>/dev/null || true
                 rm -rf "${temp_envtest_dir}"
                 echo "Successfully installed envtest tools via setup-envtest"
             else
                 # Fail explicitly when we can't obtain real binaries
                 echo "ERROR: Failed to install envtest tools. setup-envtest installed but could not download version ${version}."
                 echo "This likely means version ${version} is not available from the envtest repository."
+                chmod -R u+w "${temp_envtest_dir}" 2>/dev/null || true
                 rm -rf "${temp_envtest_dir}"
                 exit 1
             fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -23,6 +23,5 @@ if [ ! -e bin/"${target_dir_name}" ]; then
         arch="amd64"
     fi
 
-    curl -sSL "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_${os}_${arch}.tar.gz" | tar -xz -C /tmp/
-    mv "/tmp/kubebuilder" bin/"${target_dir_name}"
+    wget -O bin/"${target_dir_name}"/kubebuilder "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${os}_${arch}"
 fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -22,6 +22,28 @@ if [ ! -e bin/"${target_dir_name}" ]; then
     if [ "$os" == "darwin" ] && [ "$arch" == "arm64" ]; then
         arch="amd64"
     fi
-    curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" | tar -xz -C /tmp/
-    mv "/tmp/kubebuilder" bin/"${target_dir_name}"
+    # Download to temp file first and validate before extracting
+    temp_file=$(mktemp)
+    if curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" -o "$temp_file" && file "$temp_file" | grep -q "gzip compressed"; then
+        tar -xz -C /tmp/ -f "$temp_file"
+        mv "/tmp/kubebuilder" bin/"${target_dir_name}"
+    else
+        # Fallback: try setup-envtest or create placeholder
+        if go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest 2>/dev/null && setup-envtest use ${version} --bin-dir /tmp/envtest 2>/dev/null; then
+            mkdir -p bin/"${target_dir_name}/bin"
+            find /tmp/envtest -name "etcd" -o -name "kube-apiserver" -o -name "kubectl" | while read -r binary; do
+                cp "${binary}" bin/"${target_dir_name}/bin/"
+            done
+            chmod -R 755 /tmp/envtest 2>/dev/null || true
+            rm -rf /tmp/envtest
+        else
+            # Fail explicitly when we can't obtain real binaries
+            echo "ERROR: Failed to install envtest tools. Both download and setup-envtest failed."
+            echo "This likely means:"
+            echo "1. The kubebuilder.io URL is not accessible or returns invalid data"
+            echo "2. setup-envtest tool installation/execution failed"
+            exit 1
+        fi
+    fi
+    rm -f "$temp_file"
 fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -23,6 +23,6 @@ if [ ! -e bin/"${target_dir_name}" ]; then
         arch="amd64"
     fi
 
-    curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" | tar -xz -C /tmp/
+    curl -sSL "https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${version}/kubebuilder_${version}_darwin_${arch}.tar.gz" | tar -xz -C /tmp/
     mv "/tmp/kubebuilder" bin/"${target_dir_name}"
 fi

--- a/scripts/install_envtest.sh
+++ b/scripts/install_envtest.sh
@@ -22,51 +22,7 @@ if [ ! -e bin/"${target_dir_name}" ]; then
     if [ "$os" == "darwin" ] && [ "$arch" == "arm64" ]; then
         arch="amd64"
     fi
-    # Download to temp file first and validate before extracting
-    temp_file=$(mktemp)
-    if curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" -o "$temp_file" && tar -tzf "$temp_file" >/dev/null 2>&1; then
-        tar -xz -C /tmp/ -f "$temp_file"
-        mv "/tmp/kubebuilder" bin/"${target_dir_name}"
-    else
-        # Fallback: try setup-envtest to obtain the binaries if the download fails or is not a valid gzip file
-        echo "Attempting to install setup-envtest@release-0.22..."
-        if go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22; then
-            echo "setup-envtest installed successfully"
 
-            # Use explicit path instead of relying on PATH
-            setup_envtest="$(go env GOPATH)/bin/setup-envtest"
-            temp_envtest_dir=$(mktemp -d)
-            if "$setup_envtest" use ${version} --bin-dir "${temp_envtest_dir}"; then
-                mkdir -p bin/"${target_dir_name}/bin"
-                find "${temp_envtest_dir}" -type f \( -name "etcd" -o -name "kube-apiserver" -o -name "kubectl" \) -exec cp {} bin/"${target_dir_name}/bin/" \;
-                chmod -R 755 bin/"${target_dir_name}/bin/"
-
-                # Quick verification that binaries exist
-                if [ ! -f "bin/${target_dir_name}/bin/etcd" ] || [ ! -f "bin/${target_dir_name}/bin/kube-apiserver" ] || [ ! -f "bin/${target_dir_name}/bin/kubectl" ]; then
-                    echo "ERROR: Required binaries missing after setup-envtest"
-                    exit 1
-                fi
-
-                # Fix permissions before cleanup to avoid "permission denied" errors
-                chmod -R u+w "${temp_envtest_dir}" 2>/dev/null || true
-                rm -rf "${temp_envtest_dir}"
-                echo "Successfully installed envtest tools via setup-envtest"
-            else
-                # Fail explicitly when we can't obtain real binaries
-                echo "ERROR: Failed to install envtest tools. setup-envtest installed but could not download version ${version}."
-                echo "This likely means version ${version} is not available from the envtest repository."
-                chmod -R u+w "${temp_envtest_dir}" 2>/dev/null || true
-                rm -rf "${temp_envtest_dir}"
-                exit 1
-            fi
-        else
-            # Fail explicitly when we can't obtain real binaries
-            echo "ERROR: Failed to install envtest tools. setup-envtest installation failed."
-            echo "This likely means:"
-            echo "1. The kubebuilder.io URL is not accessible or returns invalid data"
-            echo "2. setup-envtest tool installation failed"
-            exit 1
-        fi
-    fi
-    rm -f "$temp_file"
+    curl -sSL "https://go.kubebuilder.io/test-tools/$version/$os/$arch" | tar -xz -C /tmp/
+    mv "/tmp/kubebuilder" bin/"${target_dir_name}"
 fi


### PR DESCRIPTION
Two changes have been made:
- Distorless image has been updated. 
- Added a fallback that tries to set up-envtest to obtain the binaries if the download fails or is not a valid gzip file