### PR TITLE
[CBP-42145] bump trivy-action to v0.36.0 and update base-debian12 base image to fix CVE-2026-31789

### DIFF
--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -175,7 +175,7 @@ jobs:
         if: inputs.publish
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           input: image
           format: sarif
@@ -337,7 +337,7 @@ jobs:
         if: inputs.publish
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.36.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           input: image
           format: sarif

--- a/.github/workflows/artifacts.yaml
+++ b/.github/workflows/artifacts.yaml
@@ -175,7 +175,7 @@ jobs:
         if: inputs.publish
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           input: image
           format: sarif
@@ -337,7 +337,7 @@ jobs:
         if: inputs.publish
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.32.0
+        uses: aquasecurity/trivy-action@0.36.0
         with:
           input: image
           format: sarif

--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ bin
 *.swp
 *.swo
 *~
+/.vscode/
 
 /.licensei.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ USER ${UID}:${GID}
 ENTRYPOINT ["/manager"]
 
 
-FROM gcr.io/distroless/base-debian12:latest@sha256:937c7eaaf6f3f2d38a1f8c4aeff326f0c56e4593ea152e9e8f74d976dde52f56 AS distroless
+FROM gcr.io/distroless/base-debian12:latest@sha256:58695f439f772a00009c8f6be4c183f824c1f556d74b313c30900f167e4772f8 AS distroless
 ARG UID
 ARG GID
 

--- a/Dockerfile-refresher
+++ b/Dockerfile-refresher
@@ -54,7 +54,7 @@ USER ${UID}:${GID}
 ENTRYPOINT ["/manager"]
 
 
-FROM gcr.io/distroless/base-debian12:latest@sha256:937c7eaaf6f3f2d38a1f8c4aeff326f0c56e4593ea152e9e8f74d976dde52f56 AS distroless
+FROM gcr.io/distroless/base-debian12:latest@sha256:58695f439f772a00009c8f6be4c183f824c1f556d74b313c30900f167e4772f8 AS distroless
 ARG UID
 ARG GID
 


### PR DESCRIPTION
CVE-2026-31789 requires an update to libssl3, so update the distroless/base-debian12:latest to current sha256

actions failing because the aquasecurity/trivy-action@0.32.0 is no longer available, so bump to latest release